### PR TITLE
Collateral damage

### DIFF
--- a/jsons/UnitPromotions.json
+++ b/jsons/UnitPromotions.json
@@ -60,7 +60,7 @@
   {
      "name": "Collateral Damage",
      "prerequisites": ["Volley","Siege II","Bombardment II"],
-     "uniques": ["Destroys tile improvements when attacking"],
+     "uniques": ["Destroys tile improvements when attacking <when fighting in [Enemy land] tiles>"],
      "unitTypes": ["Siege","Bomber","Ranged Water"]
   },
 //Gunpowder units get extra attack


### PR DESCRIPTION
Units can also defend or fight in their own or allied lands. Removing your own improvements is quite pointless. I personally would not use this promotion. Therefore I would modify it so that this is only valid in enemy territory.